### PR TITLE
fix : seahorse exp bug

### DIFF
--- a/Assets/Scripts/Enemy/ScriptableObjects/SeaHorese.asset
+++ b/Assets/Scripts/Enemy/ScriptableObjects/SeaHorese.asset
@@ -10,11 +10,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 02732d5e93c05a7449ad789d0d6535e6, type: 3}
-  m_Name: Seahorese
+  m_Name: SeaHorese
   m_EditorClassIdentifier: 
   enemyType: SeaHorse
   level: 1
   sightRange: 1
   speed: 1.1
-  exp: 10
+  exp: 30
   hungerValue: 10


### PR DESCRIPTION
## 📌개요
플레이어가 seahorse를 먹었을 때 경험치가 오르지 않는 문제  #86 

## 📜작업 내용
플레이어가 seahorse를 먹었을 때 경험치가 오르지 않은 것처럼 보이는 문제가 있었음
=> 10으로 설정되어 잘 안보였던 문제였음. 1단계는 30, 2단계는 70, 3단계는 140으로 설정해두었음.