### PR TITLE
fix : 레벨 3 초과 상승 현상 해결

### DIFF
--- a/Assets/Scripts/Character/Growth.cs
+++ b/Assets/Scripts/Character/Growth.cs
@@ -11,6 +11,7 @@ public class Growth : MonoBehaviour
 
     public int CurrentExp { get; private set; } = 0;
     public int CurrentLevel { get; private set; } = 1;
+    public bool doingEvolution = false;
 
     [SerializeField] private HungerSystem hungerSystem;
     [SerializeField] private PlayerMove playerMove;
@@ -50,7 +51,7 @@ public class Growth : MonoBehaviour
 
     public void AddExp(int expAmount)
     {
-        if (CurrentLevel >= MaxLevel)
+        if (CurrentExp >= expTable[MaxLevel - 1])
         {
             return;
         }
@@ -87,7 +88,11 @@ public class Growth : MonoBehaviour
             }
         }
 
-        StartCoroutine(ApplyLevelUp());
+        if(!doingEvolution)
+        {
+            doingEvolution = true;
+            StartCoroutine(ApplyLevelUp());
+        }
     }
 
     private IEnumerator ApplyLevelUp()
@@ -110,6 +115,7 @@ public class Growth : MonoBehaviour
             ChangePrefabAnimator(characterPrefabs[characterPrefabsInx]);
 
             IncreaseScale();
+            doingEvolution = false;
         }
     }
 


### PR DESCRIPTION
## 📌개요
플레이어의 경험치가 거의 차있을 때 경험치를 먹으면 level이 과하게 상승하는 현상 #88 

## 📜작업 내용
플레이어가 진화 도중에 적을 먹으면 레벨이 추가로 상승하는 문제가 있었음 => 이제는 진화하는 도중에 적을 먹어도 추가로 상승하지 않는다.